### PR TITLE
Skip chromedp when preflight HTTP GET fails

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,50 @@
 # scan
+
+使用 Go 與 [chromedp](https://github.com/chromedp/chromedp) 的網站檢測工具。
+
+## 特色
+- 從 CSV 檔案讀取 `host` 與 `port` 組合。
+- 每個組合以新的 headless Chrome 分頁執行，完成後即關閉。
+- 自動追蹤前端與後端的 redirect，並等待網路空閒（最後一個 request 結束後 500 ms 內無新 request）。
+- 取得整頁 HTML、回應代碼、頁面標題，並檢查是否含有密碼欄位或命中 allowlist。
+- 已處理過的項目不會重複執行，可支援中斷續跑，並於 log 檔每分鐘紀錄剩餘筆數。
+- 支援設定 log level，筆數相關訊息為 INFO，其餘為 WARNING。
+
+## 使用方法
+```bash
+go run main.go --file input.csv --output output.csv \
+  --concurrency 16 --timeout 5 --log scan.log --log-level info
+```
+
+### 引數
+- `--file`：輸入 CSV 路徑，預設 `input.csv`
+- `--output`：輸出 CSV 路徑，預設 `output.csv`
+- `--concurrency`：同時活躍的 Chrome 分頁上限，預設 `16`
+- `--timeout`：單個頁面最大等待秒數，預設 `5`
+- `--log`：log 檔路徑，預設 `scan.log`
+- `--log-level`：log 等級，可為 `info` 或 `warn`，預設 `info`
+
+### Input 格式
+輸入檔需為 CSV 且包含 `host`、`port` 欄位，其他欄位會原樣保留於輸出中。
+當 `port` 為 `80` 時僅以 `http` 測試；`443` 則僅以 `https` 測試；其他埠號會分別以 `http`、`https` 各測一次。
+
+### Output 欄位
+輸出欄位為原始輸入欄位加上：
+`protocol,start_time,response_code,html_header,has_login_keyword,is_matched,pass_test,error`
+
+`protocol` 會顯示實際使用的 `http` 或 `https`；`start_time` 為開始掃描的時間（RFC3339 格式）。當 `response_code ≤ 400` 或 `has_login_keyword`、`is_matched` 為 `true` 時，`pass_test` 會為 `true`。
+
+## 建置
+
+### 環境安裝
+以 Debian/Ubuntu 為例，先安裝 Go 1.21+ 與 Chrome/Chromium：
+```bash
+sudo apt update
+sudo apt install -y golang-go chromium-browser
+```
+
+### 建置流程
+```bash
+go mod tidy
+go build
+```

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module scan
+
+go 1.21
+
+require github.com/chromedp/chromedp v0.13.2

--- a/internal/scanner/client.go
+++ b/internal/scanner/client.go
@@ -1,0 +1,18 @@
+package scanner
+
+import (
+	"crypto/tls"
+	"net/http"
+	"time"
+)
+
+// newHTTPClient returns an HTTP client with the provided timeout and TLS
+// verification disabled for all requests. This ensures preflight checks succeed
+// even when the server presents an invalid certificate or redirects from HTTP
+// to HTTPS.
+func newHTTPClient(timeout time.Duration) *http.Client {
+	return &http.Client{
+		Timeout:   timeout,
+		Transport: &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}},
+	}
+}

--- a/internal/scanner/input.go
+++ b/internal/scanner/input.go
@@ -1,0 +1,110 @@
+package scanner
+
+import (
+	"encoding/csv"
+	"fmt"
+	"os"
+	"strings"
+)
+
+// ReadInput reads the input CSV and filters out records already present in the output CSV.
+func ReadInput(inputFile, outputFile string) ([]InputRecord, []string, error) {
+	Warnf("reading input file %s", inputFile)
+	f, err := os.Open(inputFile)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer f.Close()
+
+	r := csv.NewReader(f)
+	rows, err := r.ReadAll()
+	if err != nil {
+		return nil, nil, err
+	}
+	if len(rows) == 0 {
+		return nil, nil, fmt.Errorf("input file is empty")
+	}
+
+	header := rows[0]
+	hostIdx, portIdx := -1, -1
+	for i, h := range header {
+		switch strings.ToLower(h) {
+		case "host":
+			hostIdx = i
+		case "port":
+			portIdx = i
+		}
+	}
+	if hostIdx < 0 || portIdx < 0 {
+		return nil, nil, fmt.Errorf("host or port column not found")
+	}
+
+	processed := make(map[string]struct{})
+	if of, err := os.Open(outputFile); err == nil {
+		Warnf("checking existing results in %s", outputFile)
+		defer of.Close()
+		or := csv.NewReader(of)
+		outRows, err := or.ReadAll()
+		if err == nil && len(outRows) > 0 {
+			outHeader := outRows[0]
+			hIdx, pIdx, protoIdx := -1, -1, -1
+			for i, h := range outHeader {
+				switch strings.ToLower(h) {
+				case "host":
+					hIdx = i
+				case "port":
+					pIdx = i
+				case "protocol":
+					protoIdx = i
+				}
+			}
+			for i, row := range outRows {
+				if i == 0 {
+					continue
+				}
+				if hIdx < 0 || pIdx < 0 || protoIdx < 0 {
+					continue
+				}
+				if len(row) <= protoIdx {
+					continue
+				}
+				key := row[hIdx] + ":" + row[pIdx] + ":" + row[protoIdx]
+				processed[key] = struct{}{}
+			}
+			Infof("found %d processed records", len(processed))
+		} else if err != nil {
+			Warnf("read output error: %v", err)
+		}
+	}
+
+	var result []InputRecord
+	for i, row := range rows {
+		if i == 0 {
+			continue
+		}
+		if len(row) <= portIdx || len(row) <= hostIdx {
+			continue
+		}
+		host, port := row[hostIdx], row[portIdx]
+		var protos []string
+		switch port {
+		case "80":
+			protos = []string{"http"}
+		case "443":
+			protos = []string{"https"}
+		default:
+			protos = []string{"http", "https"}
+		}
+		for _, proto := range protos {
+			key := host + ":" + port + ":" + proto
+			if _, ok := processed[key]; ok {
+				continue
+			}
+			raw := make([]string, len(row))
+			copy(raw, row)
+			result = append(result, InputRecord{Host: host, Port: port, Protocol: proto, Raw: raw})
+		}
+	}
+	Infof("parsed %d new records", len(result))
+	return result, header, nil
+}

--- a/internal/scanner/log.go
+++ b/internal/scanner/log.go
@@ -1,0 +1,30 @@
+package scanner
+
+import "log"
+
+// LogLevel represents logging severity.
+type LogLevel int
+
+const (
+	LevelInfo LogLevel = iota
+	LevelWarn
+)
+
+var currentLevel LogLevel = LevelInfo
+
+// SetLogLevel updates the current logging level.
+func SetLogLevel(l LogLevel) { currentLevel = l }
+
+// Infof logs formatted info messages when the level allows.
+func Infof(format string, args ...interface{}) {
+	if currentLevel <= LevelInfo {
+		log.Printf("[INFO] "+format, args...)
+	}
+}
+
+// Warnf logs formatted warning messages when the level allows.
+func Warnf(format string, args ...interface{}) {
+	if currentLevel <= LevelWarn {
+		log.Printf("[WARN] "+format, args...)
+	}
+}

--- a/internal/scanner/output.go
+++ b/internal/scanner/output.go
@@ -1,0 +1,57 @@
+package scanner
+
+import (
+	"encoding/csv"
+	"fmt"
+	"os"
+)
+
+// WriteResults appends results to the output CSV file.
+func WriteResults(outputFile string, header []string, ch <-chan Result) {
+	Warnf("writing results to %s", outputFile)
+	_, err := os.Stat(outputFile)
+	newFile := os.IsNotExist(err)
+
+	f, err := os.OpenFile(outputFile, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
+	if err != nil {
+		Warnf("open output error: %v", err)
+		return
+	}
+	defer f.Close()
+
+	w := csv.NewWriter(f)
+	if newFile {
+		Warnf("creating new output file with header")
+		hdr := append(append([]string{}, header...),
+			"protocol", "start_time", "response_code", "html_header", "has_login_keyword", "is_matched", "pass_test", "error")
+		if err := w.Write(hdr); err != nil {
+			Warnf("write header error: %v", err)
+		}
+		w.Flush()
+	}
+
+	count := 0
+	for r := range ch {
+		row := append(append([]string{}, r.Raw...),
+			r.Protocol,
+			r.StartTime,
+			fmt.Sprintf("%d", r.ResponseCode),
+			r.HTMLHeader,
+			fmt.Sprintf("%t", r.HasLoginKeyword),
+			fmt.Sprintf("%t", r.IsMatched),
+			fmt.Sprintf("%t", r.PassTest),
+			r.Error,
+		)
+		if err := w.Write(row); err != nil {
+			Warnf("write row error for %s:%s: %v", r.Host, r.Port, err)
+		}
+		w.Flush()
+		if err := w.Error(); err != nil {
+			Warnf("flush error: %v", err)
+		} else {
+			Warnf("wrote result for %s:%s (%s)", r.Host, r.Port, r.Protocol)
+		}
+		count++
+	}
+	Infof("finished writing %d results", count)
+}

--- a/internal/scanner/process.go
+++ b/internal/scanner/process.go
@@ -1,0 +1,196 @@
+package scanner
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/chromedp/cdproto/network"
+	"github.com/chromedp/cdproto/security"
+	"github.com/chromedp/chromedp"
+)
+
+// Process first performs a simple HTTP GET; if the response code is < 400, it
+// proceeds to a full chromedp scan. Otherwise, the preflight status code is
+// returned immediately.
+func Process(rec InputRecord, timeout time.Duration) Result {
+	url := fmt.Sprintf("%s://%s:%s", rec.Protocol, rec.Host, rec.Port)
+	Warnf("preflight GET %s", url)
+
+	client := newHTTPClient(timeout)
+	res := Result{Raw: rec.Raw, Host: rec.Host, Port: rec.Port, Protocol: rec.Protocol, StartTime: time.Now().Format(time.RFC3339Nano)}
+	resp, err := client.Get(url)
+	if err != nil {
+		res.Error = err.Error()
+		Warnf("%s:%s preflight error: %v", rec.Host, rec.Port, err)
+		return res
+	}
+	defer resp.Body.Close()
+	res.ResponseCode = int64(resp.StatusCode)
+	if resp.StatusCode >= 400 {
+		Warnf("%s:%s preflight status %d - skipping deep scan", rec.Host, rec.Port, resp.StatusCode)
+		return res
+	}
+	Warnf("%s:%s preflight status %d - proceeding with browser scan", rec.Host, rec.Port, resp.StatusCode)
+	return chromedpProcess(res, timeout)
+}
+
+// chromedpProcess launches a headless browser to fetch information for a single host and port.
+func chromedpProcess(res Result, timeout time.Duration) Result {
+	url := fmt.Sprintf("%s://%s:%s", res.Protocol, res.Host, res.Port)
+	Warnf("navigate to %s", url)
+
+	opts := append(chromedp.DefaultExecAllocatorOptions[:],
+		chromedp.Flag("headless", true),
+		chromedp.Flag("disable-gpu", true),
+		chromedp.Flag("ignore-certificate-errors", true),
+		chromedp.NoSandbox,
+	)
+
+	allocCtx, cancel := chromedp.NewExecAllocator(context.Background(), opts...)
+	defer cancel()
+
+	ctx, cancelCtx := chromedp.NewContext(allocCtx)
+	defer cancelCtx()
+
+	quiet := 500 * time.Millisecond
+	var (
+		mu        sync.Mutex
+		requests  = make(map[network.RequestID]time.Time)
+		html      string
+		title     string
+		finalURL  string
+		idleTimer = time.NewTimer(time.Hour)
+		idleCh    = make(chan struct{}, 1)
+		stopCh    = make(chan struct{})
+	)
+	idleTimer.Stop()
+	var responseCode int64
+
+	chromedp.ListenTarget(ctx, func(ev interface{}) {
+		switch ev := ev.(type) {
+		case *network.EventRequestWillBeSent:
+			mu.Lock()
+			requests[ev.RequestID] = time.Now()
+			idleTimer.Stop()
+			Warnf("%s:%s request %s", res.Host, res.Port, ev.Request.URL)
+			mu.Unlock()
+		case *network.EventLoadingFinished:
+			mu.Lock()
+			delete(requests, ev.RequestID)
+			if len(requests) == 0 {
+				idleTimer.Reset(quiet)
+				Warnf("%s:%s network idle timer started", res.Host, res.Port)
+			}
+			Warnf("%s:%s request finished id=%s (active=%d)", res.Host, res.Port, ev.RequestID, len(requests))
+			mu.Unlock()
+		case *network.EventLoadingFailed:
+			mu.Lock()
+			delete(requests, ev.RequestID)
+			if len(requests) == 0 {
+				idleTimer.Reset(quiet)
+				Warnf("%s:%s network idle timer started", res.Host, res.Port)
+			}
+			Warnf("%s:%s request failed id=%s (active=%d)", res.Host, res.Port, ev.RequestID, len(requests))
+			mu.Unlock()
+		case *network.EventResponseReceived:
+			if ev.Type == network.ResourceTypeDocument && responseCode == 0 {
+				responseCode = int64(ev.Response.Status)
+				Warnf("%s:%s response %d for %s", res.Host, res.Port, responseCode, ev.Response.URL)
+			}
+		case *security.EventCertificateError:
+			Warnf("%s:%s certificate error %s", res.Host, res.Port, ev.ErrorType)
+			go func(id security.RequestID) {
+				_ = chromedp.Run(ctx, security.HandleCertificateError(ev.EventID, security.CertificateErrorActionContinue))
+			}(ev.RequestID)
+		}
+	})
+
+	go func() {
+		<-idleTimer.C
+		idleCh <- struct{}{}
+	}()
+
+	ticker := time.NewTicker(100 * time.Millisecond)
+	go func() {
+		for {
+			select {
+			case <-ticker.C:
+				mu.Lock()
+				now := time.Now()
+				for id, start := range requests {
+					if now.Sub(start) > quiet {
+						Warnf("%s:%s pruning lingering request %s", res.Host, res.Port, id)
+						delete(requests, id)
+					}
+				}
+				if len(requests) == 0 {
+					idleTimer.Reset(quiet)
+				}
+				mu.Unlock()
+			case <-stopCh:
+				ticker.Stop()
+				return
+			}
+		}
+	}()
+
+	timeoutTimer := time.NewTimer(timeout)
+	if err := chromedp.Run(ctx,
+		network.Enable(),
+		security.Enable(),
+		security.SetIgnoreCertificateErrors(true),
+		chromedp.Navigate(url),
+	); err != nil {
+		res.Error = err.Error()
+		Warnf("navigate error %s:%s: %v", res.Host, res.Port, err)
+		close(stopCh)
+		return res
+	}
+
+	select {
+	case <-idleCh:
+		Warnf("%s:%s network idle", res.Host, res.Port)
+	case <-timeoutTimer.C:
+		mu.Lock()
+		lingering := make([]string, 0, len(requests))
+		for id := range requests {
+			lingering = append(lingering, string(id))
+		}
+		mu.Unlock()
+		Warnf("%s:%s context timeout: lingering requests %v", res.Host, res.Port, lingering)
+	}
+	timeoutTimer.Stop()
+	close(stopCh)
+
+	if err := chromedp.Run(ctx,
+		chromedp.OuterHTML("html", &html),
+		chromedp.Title(&title),
+		chromedp.Location(&finalURL),
+	); err != nil {
+		res.Error = err.Error()
+		Warnf("%s:%s capture error: %v", res.Host, res.Port, err)
+		return res
+	}
+
+	res.ResponseCode = responseCode
+	res.HTMLHeader = title
+	res.HasLoginKeyword = strings.Contains(strings.ToLower(html), "type=\"password\"")
+	for _, u := range AllowList {
+		if finalURL == u {
+			res.IsMatched = true
+			break
+		}
+	}
+	if res.ResponseCode <= 400 {
+		res.PassTest = true
+	}
+	if res.HasLoginKeyword || res.IsMatched {
+		res.PassTest = true
+	}
+	Warnf("%s:%s finalURL=%s title=%q html=%dB", res.Host, res.Port, finalURL, title, len(html))
+	Warnf("%s:%s result code=%d matched=%t login=%t pass=%t", res.Host, res.Port, res.ResponseCode, res.IsMatched, res.HasLoginKeyword, res.PassTest)
+	return res
+}

--- a/internal/scanner/process_test.go
+++ b/internal/scanner/process_test.go
@@ -1,0 +1,64 @@
+package scanner
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestProcessNetworkIdlePrunesLongRequests verifies that a long-polling request
+// does not block the network idle detection indefinitely.
+func TestProcessNetworkIdlePrunesLongRequests(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/":
+			w.Header().Set("Content-Type", "text/html")
+			if _, err := fmt.Fprint(w, "<!doctype html><script>fetch('/slow');</script>"); err != nil {
+				t.Fatalf("write html: %v", err)
+			}
+		case "/slow":
+			time.Sleep(2 * time.Second)
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	hostPort := strings.TrimPrefix(srv.URL, "http://")
+	parts := strings.Split(hostPort, ":")
+	rec := InputRecord{Host: parts[0], Port: parts[1], Protocol: "http", Raw: []string{parts[0], parts[1]}}
+
+	res := Process(rec, 3*time.Second)
+	if res.Error != "" {
+		t.Fatalf("process returned error: %v", res.Error)
+	}
+}
+
+// TestProcessSetsPassTestForSuccessfulCode ensures that a successful response
+// (status <= 400) marks the result as passing even without login keywords or
+// allow-list matches.
+func TestProcessSetsPassTestForSuccessfulCode(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		if _, err := fmt.Fprint(w, "<html><body>ok</body></html>"); err != nil {
+			t.Fatalf("write html: %v", err)
+		}
+	}))
+	defer srv.Close()
+
+	hostPort := strings.TrimPrefix(srv.URL, "http://")
+	parts := strings.Split(hostPort, ":")
+	rec := InputRecord{Host: parts[0], Port: parts[1], Protocol: "http", Raw: []string{parts[0], parts[1]}}
+
+	res := Process(rec, 3*time.Second)
+	if res.ResponseCode != 200 {
+		t.Fatalf("expected response code 200, got %d", res.ResponseCode)
+	}
+	if !res.PassTest {
+		t.Fatalf("expected pass_test true for response code %d", res.ResponseCode)
+	}
+}

--- a/internal/scanner/types.go
+++ b/internal/scanner/types.go
@@ -1,0 +1,27 @@
+package scanner
+
+// InputRecord represents a host, port, and protocol combination.
+type InputRecord struct {
+	Host     string
+	Port     string
+	Protocol string
+	Raw      []string
+}
+
+// Result holds the scan outcome for a single host, port, and protocol.
+type Result struct {
+	Raw             []string
+	Host            string
+	Port            string
+	Protocol        string
+	StartTime       string
+	ResponseCode    int64
+	HTMLHeader      string
+	HasLoginKeyword bool
+	IsMatched       bool
+	PassTest        bool
+	Error           string
+}
+
+// AllowList contains URLs that are considered valid landing pages.
+var AllowList = []string{}

--- a/main.go
+++ b/main.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"flag"
+	"io"
+	"log"
+	"os"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"scan/internal/scanner"
+)
+
+func main() {
+	log.SetFlags(log.LstdFlags | log.Lmicroseconds)
+	inputPath := flag.String("file", "input.csv", "input CSV file containing host and port columns")
+	outputPath := flag.String("output", "output.csv", "output CSV file path")
+	concurrency := flag.Int("concurrency", 16, "maximum concurrent chromedp tabs")
+	timeoutSec := flag.Int("timeout", 5, "chromedp timeout in seconds")
+	logPath := flag.String("log", "scan.log", "log file path")
+	levelFlag := flag.String("log-level", "info", "log level (info or warn)")
+	flag.Parse()
+
+	switch strings.ToLower(*levelFlag) {
+	case "warn", "warning":
+		scanner.SetLogLevel(scanner.LevelWarn)
+	default:
+		scanner.SetLogLevel(scanner.LevelInfo)
+	}
+
+	lf, err := os.OpenFile(*logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
+	if err != nil {
+		log.Fatalf("open log file %s: %v", *logPath, err)
+	}
+	defer lf.Close()
+	log.SetOutput(io.MultiWriter(os.Stdout, lf))
+
+	scanner.Warnf("flags: file=%s output=%s concurrency=%d timeout=%d log=%s", *inputPath, *outputPath, *concurrency, *timeoutSec, *logPath)
+	inputRecords, header, err := scanner.ReadInput(*inputPath, *outputPath)
+	if err != nil {
+		scanner.Warnf("read input error: %v", err)
+		return
+	}
+	scanner.Infof("input_records: %d", len(inputRecords))
+	if len(inputRecords) == 0 {
+		scanner.Infof("no input records to process, exiting")
+		return
+	}
+
+	outCh := make(chan scanner.Result)
+	var (
+		wg       sync.WaitGroup
+		writerWg sync.WaitGroup
+	)
+
+	writerWg.Add(1)
+	go func() {
+		defer writerWg.Done()
+		scanner.WriteResults(*outputPath, header, outCh)
+	}()
+
+	var remaining int64 = int64(len(inputRecords))
+	ticker := time.NewTicker(time.Minute)
+	go func() {
+		for range ticker.C {
+			rem := atomic.LoadInt64(&remaining)
+			scanner.Infof("tasks remaining: %d", rem)
+			if rem <= 0 {
+				ticker.Stop()
+				return
+			}
+		}
+	}()
+
+	sem := make(chan struct{}, *concurrency)
+	for _, rec := range inputRecords {
+		wg.Add(1)
+		sem <- struct{}{}
+		go func(r scanner.InputRecord) {
+			defer wg.Done()
+			defer func() { <-sem }()
+			scanner.Warnf("start processing %s:%s (%s)", r.Host, r.Port, r.Protocol)
+			res := scanner.Process(r, time.Duration(*timeoutSec)*time.Second)
+			outCh <- res
+			atomic.AddInt64(&remaining, -1)
+			scanner.Warnf("finish processing %s:%s (%s)", r.Host, r.Port, r.Protocol)
+		}(rec)
+	}
+
+	wg.Wait()
+	close(outCh)
+	ticker.Stop()
+	writerWg.Wait()
+	scanner.Warnf("all tasks completed")
+}


### PR DESCRIPTION
## Summary
- perform lightweight HTTP GET and only run chromedp when status code is below 400
- ignore TLS validation in preflight just like the browser phase
- add log flag to write output to a file and report remaining tasks every minute
- add log-level flag so count-related messages log at INFO and others at WARN
- refactor scanning logic into a dedicated `scanner` package separating logging, CSV I/O, and browser interactions
- relocate the scanner package under `internal/scanner` for idiomatic Go module layout
- record start timestamp for each scan and include a `start_time` column in results
- mark `pass_test` true whenever the final response code is 400 or lower
- disable TLS verification in preflight HTTP client and handle Chrome certificate errors during navigation
- update chromedp to v0.13.2 and adjust certificate error override API

## Testing
- `go mod tidy` (github.com/chromedp/chromedp@v0.13.2: Get "https://proxy.golang.org/github.com/chromedp/chromedp/@v/v0.13.2.mod": Forbidden)
- `go build ./...` (internal/scanner/process.go:10:2: github.com/chromedp/chromedp@v0.13.2: missing go.sum entry for go.mod file)
- `go test ./...` (# scan/internal/scanner: missing go.sum entry for module providing package github.com/chromedp/chromedp)


------
https://chatgpt.com/codex/tasks/task_e_68ab20d8a60c83239498668a671c5004